### PR TITLE
Spelling fixes for Beyond Zork

### DIFF
--- a/events.zil
+++ b/events.zil
@@ -2668,7 +2668,7 @@ THE ,FCROWD ,PTAB "\"Greetings, brave ">
 		<TELL CTHE ,GRINDER 
 " looks you up and down. \"Peasants,\" he sniffs, adjusting a knob on his "
 'GURDY ". \"Like unto sheep.\"|
-  He turns the crank of " THE ,GURDY ", and the air is filled with the combined stench of five herds of sheep, accompanied by a cacophany of hateful bleating." CR>)
+  He turns the crank of " THE ,GURDY ", and the air is filled with the combined stench of five herds of sheep, accompanied by a cacophony of hateful bleating." CR>)
 	       (<EQUAL? ,GRTIMER 2>
 		<UNMAKE ,NYMPH ,LIVING>
 		<TELL "Ignoring you for the moment, " THE ,GRINDER 

--- a/rarities.zil
+++ b/rarities.zil
@@ -1748,7 +1748,7 @@ By what Name shall your character be known?">
 		<SETG INCOLOR <GETB .TBL 2>>
 		<SETG GCOLOR <GETB .TBL 3>>
 		<V-REFRESH>
-	        <TELL CR "[Color pallette " N ,PALLETTE
+	        <TELL CR "[Color palette " N ,PALLETTE
 		      " of " N .CNT ".]" CR>
 		<COND (<IGRTR? PALLETTE .CNT>
 		       <SETG PALLETTE 1>)>


### PR DESCRIPTION
These are the spelling fixes for Beyond Zork from The ZIL Files. The usual caveats apply: I'm not a native English speaker, so please check that the fixes are correct.